### PR TITLE
Fix: optically center board text within its row

### DIFF
--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -57,4 +57,5 @@ const Text = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
+  transform: translateY(0.09em);
 `;


### PR DESCRIPTION
Bebas Neue's caps occupy the top ~75% of its em-square, leaving the bottom ~25% empty for descenders that never appear in this all-caps font. With align-items: center the line box is centered, but the visible cap-block ends up sitting in the upper half of the row.

Translate the text down by 0.09em so the cap-block centers in the row instead of the line box.

https://claude.ai/code/session_011pGzV6osudSkwYLZ93A74R