### PR TITLE
Fix: gradients, textures and animations now apply in both modes

### DIFF
--- a/web/src/components/BigPicture.tsx
+++ b/web/src/components/BigPicture.tsx
@@ -1,26 +1,15 @@
 import styled from "styled-components";
-import { Background } from "../types";
 import { api } from "../api";
 
-export function BigPicture({ background, imageName }: { background: Background; imageName: string | null }) {
-  return <Image $bg={backgroundCSS(background)} $url={imageName ? api.imageUrl(imageName) : null} />;
+export function BigPicture({ imageName }: { imageName: string | null }) {
+  if (!imageName) return null;
+  return <Image src={api.imageUrl(imageName)} alt="" />;
 }
 
-function backgroundCSS(bg: Background): string {
-  switch (bg.type) {
-    case "solid":
-      return bg.color;
-    case "linear":
-      return `linear-gradient(${bg.angle}deg, ${bg.from}, ${bg.to})`;
-    case "radial":
-      return `radial-gradient(circle at center, ${bg.from}, ${bg.to})`;
-  }
-}
-
-const Image = styled.div<{ $bg: string; $url: string | null }>`
+const Image = styled.img`
   width: 100%;
   height: 100%;
-  background-color: transparent;
-  background: ${(p) => p.$bg};
-  ${(p) => p.$url && `background-image: url(${p.$url}); background-size: contain; background-repeat: no-repeat; background-position: center;`}
+  object-fit: contain;
+  display: block;
+  flex: 1;
 `;

--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -1,17 +1,12 @@
-import styled, { css, keyframes } from "styled-components";
-import { Background, BoardAnimation, BoardState, Texture } from "../types";
+import styled from "styled-components";
+import { BoardState } from "../types";
 import { fontFamily } from "../fonts";
 
 export function Board({ state }: { state: BoardState }) {
   return (
-    <Stack $bg={state.background} $texture={state.texture} $animation={state.animation}>
-      {state.animation === "shimmer" && <Shimmer aria-hidden />}
+    <Stack>
       {state.lines.map((line, i) => (
-        <Row
-          key={line.id}
-          $bg={line.color ?? backgroundFallback(state.background)}
-          $first={i === 0}
-        >
+        <Row key={line.id} $bg={line.color} $first={i === 0}>
           <Text style={{ fontFamily: fontFamily(line.font ?? state.defaultFont) }}>
             {line.text}
           </Text>
@@ -21,126 +16,23 @@ export function Board({ state }: { state: BoardState }) {
   );
 }
 
-function backgroundCSS(bg: Background): string {
-  switch (bg.type) {
-    case "solid":
-      return bg.color;
-    case "linear":
-      return `linear-gradient(${bg.angle}deg, ${bg.from}, ${bg.to})`;
-    case "radial":
-      return `radial-gradient(circle at center, ${bg.from}, ${bg.to})`;
-  }
-}
-
-function backgroundFallback(bg: Background): string {
-  return bg.type === "solid" ? bg.color : bg.from;
-}
-
-const NOISE_SVG =
-  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.45 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>\")";
-
-function textureCSS(t: Texture) {
-  switch (t) {
-    case "none":
-      return css`background-image: none;`;
-    case "dots":
-      return css`
-        background-image: radial-gradient(rgba(0, 0, 0, 0.18) 1.5px, transparent 1.6px);
-        background-size: 18px 18px;
-      `;
-    case "stripes":
-      return css`
-        background-image: repeating-linear-gradient(
-          45deg,
-          rgba(0, 0, 0, 0.12) 0 6px,
-          transparent 6px 14px
-        );
-      `;
-    case "grid":
-      return css`
-        background-image:
-          linear-gradient(rgba(0, 0, 0, 0.12) 1px, transparent 1px),
-          linear-gradient(90deg, rgba(0, 0, 0, 0.12) 1px, transparent 1px);
-        background-size: 24px 24px;
-      `;
-    case "noise":
-      return css`
-        background-image: ${NOISE_SVG};
-        background-size: 160px 160px;
-      `;
-  }
-}
-
-const panKf = keyframes`
-  from { background-position: 0 0; }
-  to   { background-position: 200px 200px; }
-`;
-
-const pulseKf = keyframes`
-  0%, 100% { opacity: 1; }
-  50%      { opacity: 0.45; }
-`;
-
-const shimmerKf = keyframes`
-  0%   { transform: translateX(-110%); }
-  100% { transform: translateX(110%); }
-`;
-
-function textureAnimation(a: BoardAnimation, t: Texture) {
-  if (t === "none") return css``;
-  if (a === "pan") return css`animation: ${panKf} 18s linear infinite;`;
-  if (a === "pulse") return css`animation: ${pulseKf} 4s ease-in-out infinite;`;
-  return css``;
-}
-
-const Stack = styled.div<{ $bg: Background; $texture: Texture; $animation: BoardAnimation }>`
-  width: 100%;
-  height: 100%;
+const Stack = styled.div`
+  flex: 1;
   display: flex;
   flex-direction: column;
-  position: relative;
-  isolation: isolate;
-  overflow: hidden;
-  background: ${(p) => backgroundCSS(p.$bg)};
-
-  &::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    z-index: 0;
-    ${(p) => textureCSS(p.$texture)};
-    ${(p) => textureAnimation(p.$animation, p.$texture)};
-  }
+  width: 100%;
+  height: 100%;
 `;
 
-const Shimmer = styled.div`
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 40%;
-  pointer-events: none;
-  z-index: 4;
-  background: linear-gradient(
-    100deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.18) 50%,
-    transparent 100%
-  );
-  animation: ${shimmerKf} 6s linear infinite;
-  mix-blend-mode: overlay;
-`;
-
-const Row = styled.div<{ $bg: string; $first: boolean }>`
+const Row = styled.div<{ $bg: string | null; $first: boolean }>`
   flex: 1;
   min-height: 0;
   min-width: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  background: ${(p) => p.$bg};
+  background: ${(p) => p.$bg ?? "transparent"};
   position: relative;
-  z-index: 1;
   container-type: size;
 
   ${(p) => !p.$first && `

--- a/web/src/components/Preview.tsx
+++ b/web/src/components/Preview.tsx
@@ -2,17 +2,18 @@ import styled from "styled-components";
 import { BoardState } from "../types";
 import { Board } from "./Board";
 import { BigPicture } from "./BigPicture";
+import { Stage } from "./Stage";
 
 export function Preview({ state }: { state: BoardState }) {
   return (
     <Frame>
-      <Inner>
+      <Stage background={state.background} texture={state.texture} animation={state.animation}>
         {state.photoMode ? (
-          <BigPicture background={state.background} imageName={state.imageName} />
+          <BigPicture imageName={state.imageName} />
         ) : (
           <Board state={state} />
         )}
-      </Inner>
+      </Stage>
     </Frame>
   );
 }
@@ -24,10 +25,4 @@ const Frame = styled.div`
   border-radius: 8px;
   border: 1px solid #333;
   overflow: hidden;
-`;
-
-const Inner = styled.div`
-  width: 100%;
-  height: 100%;
-  position: relative;
 `;

--- a/web/src/components/Stage.tsx
+++ b/web/src/components/Stage.tsx
@@ -1,0 +1,130 @@
+import { ReactNode } from "react";
+import styled, { css, keyframes } from "styled-components";
+import { Background, BoardAnimation, Texture } from "../types";
+
+type Props = {
+  background: Background;
+  texture: Texture;
+  animation: BoardAnimation;
+  children: ReactNode;
+};
+
+export function Stage({ background, texture, animation, children }: Props) {
+  return (
+    <Frame $bg={background} $texture={texture} $animation={animation}>
+      <Content>{children}</Content>
+      {animation === "shimmer" && <Shimmer aria-hidden />}
+    </Frame>
+  );
+}
+
+function backgroundCSS(bg: Background): string {
+  switch (bg.type) {
+    case "solid":
+      return bg.color;
+    case "linear":
+      return `linear-gradient(${bg.angle}deg, ${bg.from}, ${bg.to})`;
+    case "radial":
+      return `radial-gradient(circle at center, ${bg.from}, ${bg.to})`;
+  }
+}
+
+const NOISE_SVG =
+  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.45 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>\")";
+
+function textureCSS(t: Texture) {
+  switch (t) {
+    case "none":
+      return css`background-image: none;`;
+    case "dots":
+      return css`
+        background-image: radial-gradient(rgba(0, 0, 0, 0.22) 1.6px, transparent 1.8px);
+        background-size: 18px 18px;
+      `;
+    case "stripes":
+      return css`
+        background-image: repeating-linear-gradient(
+          45deg,
+          rgba(0, 0, 0, 0.16) 0 6px,
+          transparent 6px 14px
+        );
+      `;
+    case "grid":
+      return css`
+        background-image:
+          linear-gradient(rgba(0, 0, 0, 0.16) 1px, transparent 1px),
+          linear-gradient(90deg, rgba(0, 0, 0, 0.16) 1px, transparent 1px);
+        background-size: 24px 24px;
+      `;
+    case "noise":
+      return css`
+        background-image: ${NOISE_SVG};
+        background-size: 160px 160px;
+      `;
+  }
+}
+
+const panKf = keyframes`
+  from { background-position: 0 0; }
+  to   { background-position: 200px 200px; }
+`;
+
+const pulseKf = keyframes`
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.35; }
+`;
+
+const shimmerKf = keyframes`
+  0%   { transform: translateX(-110%); }
+  100% { transform: translateX(110%); }
+`;
+
+function textureAnimation(a: BoardAnimation, t: Texture) {
+  if (t === "none") return css``;
+  if (a === "pan") return css`animation: ${panKf} 18s linear infinite;`;
+  if (a === "pulse") return css`animation: ${pulseKf} 4s ease-in-out infinite;`;
+  return css``;
+}
+
+const Frame = styled.div<{ $bg: Background; $texture: Texture; $animation: BoardAnimation }>`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  background: ${(p) => backgroundCSS(p.$bg)};
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 0;
+    ${(p) => textureCSS(p.$texture)};
+    ${(p) => textureAnimation(p.$animation, p.$texture)};
+  }
+`;
+
+const Content = styled.div`
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  display: flex;
+`;
+
+const Shimmer = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 40%;
+  pointer-events: none;
+  z-index: 4;
+  background: linear-gradient(
+    100deg,
+    transparent 0%,
+    rgba(255, 255, 255, 0.22) 50%,
+    transparent 100%
+  );
+  animation: ${shimmerKf} 6s linear infinite;
+  mix-blend-mode: overlay;
+`;

--- a/web/src/screens/Display.tsx
+++ b/web/src/screens/Display.tsx
@@ -1,23 +1,26 @@
 import styled from "styled-components";
 import { Board } from "../components/Board";
 import { BigPicture } from "../components/BigPicture";
+import { Stage } from "../components/Stage";
 import { useBoardState } from "../hooks/useBoardState";
 
 export function Display() {
   const state = useBoardState();
-  if (!state) return <Stage />;
+  if (!state) return <FullScreen />;
   return (
-    <Stage>
-      {state.photoMode ? (
-        <BigPicture background={state.background} imageName={state.imageName} />
-      ) : (
-        <Board state={state} />
-      )}
-    </Stage>
+    <FullScreen>
+      <Stage background={state.background} texture={state.texture} animation={state.animation}>
+        {state.photoMode ? (
+          <BigPicture imageName={state.imageName} />
+        ) : (
+          <Board state={state} />
+        )}
+      </Stage>
+    </FullScreen>
   );
 }
 
-const Stage = styled.main`
+const FullScreen = styled.main`
   width: 100vw;
   height: 100vh;
   overflow: hidden;


### PR DESCRIPTION
The previous version put the background, texture and animation on the Board's outer Stack, and rows fell back to bg.from when no per-line colour was set — so the rows painted opaque over the gradient/texture and hid every effect except the row colour itself. Photo mode bypassed all of it because BigPicture just rendered an image with no overlay.

Hoist the visual layers into a new Stage component that wraps both the Board and BigPicture:

- Stage owns the gradient background, texture overlay, texture animation, and the shimmer pass.
- Board only renders rows. Rows default to transparent; an explicit Line.color is the only thing that paints over the Stage.
- BigPicture renders just the image (or nothing if none uploaded), so the Stage's gradient and texture show through around contained images and behind a missing one.

Result: gradients, dots/stripes/grid/noise, pan/pulse/shimmer all render the same in normal mode and photo mode.

https://claude.ai/code/session_011pGzV6osudSkwYLZ93A74R