### PR TITLE
Add 3D-style textures, text effects, and proper descender centering

### DIFF
--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -1,7 +1,7 @@
 import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
-import { Background, BoardAnimation, BoardState, DEFAULT_FONT, DEFAULT_STATE, Line, Texture } from "./types.js";
+import { Background, BoardAnimation, BoardState, DEFAULT_FONT, DEFAULT_STATE, Line, TextEffect, Texture } from "./types.js";
 
 const DB_PATH = process.env.DB_PATH ?? "./data/messageboard.db";
 
@@ -35,8 +35,9 @@ export function setState(state: BoardState): BoardState {
   return stamped;
 }
 
-const TEXTURES: Texture[] = ["none", "dots", "stripes", "grid", "noise"];
+const TEXTURES: Texture[] = ["none", "dots", "stripes", "grid", "noise", "paper", "fabric", "clouds", "tarmac"];
 const ANIMATIONS: BoardAnimation[] = ["none", "pan", "pulse", "shimmer"];
+const TEXT_EFFECTS: TextEffect[] = ["none", "shadow", "emboss", "engrave", "outline", "glow"];
 
 function migrate(raw: unknown): BoardState {
   const r = (raw ?? {}) as Record<string, unknown>;
@@ -49,6 +50,7 @@ function migrate(raw: unknown): BoardState {
     texture: TEXTURES.includes(r.texture as Texture) ? (r.texture as Texture) : "none",
     animation: ANIMATIONS.includes(r.animation as BoardAnimation) ? (r.animation as BoardAnimation) : "none",
     defaultFont: typeof r.defaultFont === "string" && r.defaultFont ? r.defaultFont : DEFAULT_FONT,
+    defaultTextEffect: TEXT_EFFECTS.includes(r.defaultTextEffect as TextEffect) ? (r.defaultTextEffect as TextEffect) : "none",
     photoMode: r.photoMode === true,
     imageName: typeof r.imageName === "string" ? r.imageName : null,
     updatedAt: typeof r.updatedAt === "number" ? r.updatedAt : 0,
@@ -62,6 +64,7 @@ function migrateLine(raw: unknown, i: number): Line {
     text: typeof r.text === "string" ? r.text : "",
     color: typeof r.color === "string" ? r.color : null,
     font: typeof r.font === "string" ? r.font : null,
+    textEffect: TEXT_EFFECTS.includes(r.textEffect as TextEffect) ? (r.textEffect as TextEffect) : null,
   };
 }
 

--- a/api/src/routes/state.ts
+++ b/api/src/routes/state.ts
@@ -3,12 +3,13 @@ import { streamSSE } from "hono/streaming";
 import { getState, setState } from "../db.js";
 import { publish, subscribe } from "../events.js";
 import { requireAuth } from "../auth.js";
-import { Background, BoardAnimation, BoardState, Line, Texture } from "../types.js";
+import { Background, BoardAnimation, BoardState, Line, TextEffect, Texture } from "../types.js";
 
 const app = new Hono();
 
-const TEXTURES: Texture[] = ["none", "dots", "stripes", "grid", "noise"];
+const TEXTURES: Texture[] = ["none", "dots", "stripes", "grid", "noise", "paper", "fabric", "clouds", "tarmac"];
 const ANIMATIONS: BoardAnimation[] = ["none", "pan", "pulse", "shimmer"];
+const TEXT_EFFECTS: TextEffect[] = ["none", "shadow", "emboss", "engrave", "outline", "glow"];
 
 app.get("/", (c) => c.json(getState()));
 
@@ -21,6 +22,7 @@ app.post("/", requireAuth, async (c) => {
     texture: TEXTURES.includes(body.texture as Texture) ? (body.texture as Texture) : current.texture,
     animation: ANIMATIONS.includes(body.animation as BoardAnimation) ? (body.animation as BoardAnimation) : current.animation,
     defaultFont: typeof body.defaultFont === "string" && body.defaultFont ? body.defaultFont : current.defaultFont,
+    defaultTextEffect: TEXT_EFFECTS.includes(body.defaultTextEffect as TextEffect) ? (body.defaultTextEffect as TextEffect) : current.defaultTextEffect,
     photoMode: typeof body.photoMode === "boolean" ? body.photoMode : current.photoMode,
     imageName: body.imageName === undefined ? current.imageName : body.imageName,
     updatedAt: 0,
@@ -58,11 +60,13 @@ function validateLines(input: unknown): Line[] | null {
     if (typeof r.id !== "string" || typeof r.text !== "string") return null;
     if (r.color !== null && typeof r.color !== "string") return null;
     if (r.font !== undefined && r.font !== null && typeof r.font !== "string") return null;
+    if (r.textEffect !== undefined && r.textEffect !== null && !TEXT_EFFECTS.includes(r.textEffect as TextEffect)) return null;
     lines.push({
       id: r.id,
       text: r.text.slice(0, 64),
       color: typeof r.color === "string" ? r.color : null,
       font: typeof r.font === "string" ? r.font : null,
+      textEffect: TEXT_EFFECTS.includes(r.textEffect as TextEffect) ? (r.textEffect as TextEffect) : null,
     });
   }
   return lines;

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -3,14 +3,16 @@ export type LinearBackground = { type: "linear"; from: string; to: string; angle
 export type RadialBackground = { type: "radial"; from: string; to: string };
 export type Background = SolidBackground | LinearBackground | RadialBackground;
 
-export type Texture = "none" | "dots" | "stripes" | "grid" | "noise";
+export type Texture = "none" | "dots" | "stripes" | "grid" | "noise" | "paper" | "fabric" | "clouds" | "tarmac";
 export type BoardAnimation = "none" | "pan" | "pulse" | "shimmer";
+export type TextEffect = "none" | "shadow" | "emboss" | "engrave" | "outline" | "glow";
 
 export type Line = {
   id: string;
   text: string;
   color: string | null;
   font: string | null;
+  textEffect: TextEffect | null;
 };
 
 export type BoardState = {
@@ -19,6 +21,7 @@ export type BoardState = {
   texture: Texture;
   animation: BoardAnimation;
   defaultFont: string;
+  defaultTextEffect: TextEffect;
   photoMode: boolean;
   imageName: string | null;
   updatedAt: number;
@@ -28,14 +31,15 @@ export const DEFAULT_FONT = "Bebas Neue";
 
 export const DEFAULT_STATE: BoardState = {
   lines: [
-    { id: "l1", text: "", color: null, font: null },
-    { id: "l2", text: "", color: null, font: null },
-    { id: "l3", text: "", color: null, font: null },
+    { id: "l1", text: "", color: null, font: null, textEffect: null },
+    { id: "l2", text: "", color: null, font: null, textEffect: null },
+    { id: "l3", text: "", color: null, font: null, textEffect: null },
   ],
   background: { type: "solid", color: "#000000" },
   texture: "none",
   animation: "none",
   defaultFont: DEFAULT_FONT,
+  defaultTextEffect: "none",
   photoMode: false,
   imageName: null,
   updatedAt: 0,

--- a/web/src/components/BackgroundEditor.tsx
+++ b/web/src/components/BackgroundEditor.tsx
@@ -18,7 +18,7 @@ const TYPE_LABEL: Record<Background["type"], string> = {
   radial: "Radial gradient",
 };
 
-const TEXTURES: Texture[] = ["none", "dots", "stripes", "grid", "noise"];
+const TEXTURES: Texture[] = ["none", "dots", "stripes", "grid", "noise", "paper", "fabric", "clouds", "tarmac"];
 const ANIMATIONS: BoardAnimation[] = ["none", "pan", "pulse", "shimmer"];
 
 export function BackgroundEditor({ background, texture, animation, onBackground, onTexture, onAnimation }: Props) {

--- a/web/src/components/Board.tsx
+++ b/web/src/components/Board.tsx
@@ -1,13 +1,19 @@
 import styled from "styled-components";
 import { BoardState } from "../types";
 import { fontFamily } from "../fonts";
+import { textEffectStyle } from "../effects";
 
 export function Board({ state }: { state: BoardState }) {
   return (
     <Stack>
       {state.lines.map((line, i) => (
         <Row key={line.id} $bg={line.color} $first={i === 0}>
-          <Text style={{ fontFamily: fontFamily(line.font ?? state.defaultFont) }}>
+          <Text
+            style={{
+              fontFamily: fontFamily(line.font ?? state.defaultFont),
+              ...textEffectStyle(line.textEffect ?? state.defaultTextEffect),
+            }}
+          >
             {line.text}
           </Text>
         </Row>
@@ -72,4 +78,10 @@ const Text = styled.span`
   position: relative;
   z-index: 2;
   transform: translateY(0.09em);
+
+  @supports (text-box-trim: trim-both) {
+    text-box-trim: trim-both;
+    text-box-edge: cap text;
+    transform: none;
+  }
 `;

--- a/web/src/components/LineEditor.tsx
+++ b/web/src/components/LineEditor.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import { Line } from "../types";
 import { ColorSwatch } from "./ColorSwatch";
 import { FontSelect } from "./FontSelect";
+import { TextEffectSelect } from "./TextEffectSelect";
 import { fontFamily } from "../fonts";
 
 type Props = {
@@ -47,14 +48,23 @@ export function LineEditor({
         maxLength={32}
         onChange={(e) => onChange({ ...line, text: e.target.value })}
       />
-      <FontSelect
-        compact
-        value={line.font}
-        fallback={defaultFont}
-        onChange={(font) => onChange({ ...line, font })}
-        allowInherit
-        inheritLabel="↳ default"
-      />
+      <SelectStack>
+        <FontSelect
+          compact
+          value={line.font}
+          fallback={defaultFont}
+          onChange={(font) => onChange({ ...line, font })}
+          allowInherit
+          inheritLabel="↳ default font"
+        />
+        <TextEffectSelect
+          compact
+          value={line.textEffect}
+          onChange={(textEffect) => onChange({ ...line, textEffect })}
+          allowInherit
+          inheritLabel="↳ default effect"
+        />
+      </SelectStack>
       <ColorSwatch
         value={effectiveColor}
         onChange={(hex) => onChange({ ...line, color: hex })}
@@ -66,6 +76,13 @@ export function LineEditor({
     </Row>
   );
 }
+
+const SelectStack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 150px;
+`;
 
 const Row = styled.div`
   display: flex;

--- a/web/src/components/Stage.tsx
+++ b/web/src/components/Stage.tsx
@@ -29,8 +29,29 @@ function backgroundCSS(bg: Background): string {
   }
 }
 
-const NOISE_SVG =
-  "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.45 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>\")";
+const NOISE_SVG = svgUrl(
+  "<filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.45 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/>",
+  160
+);
+
+const PAPER_SVG = svgUrl(
+  "<filter id='p'><feTurbulence type='fractalNoise' baseFrequency='0.045' numOctaves='5' stitchTiles='stitch' seed='3'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.32 0'/></filter><rect width='100%' height='100%' filter='url(%23p)'/>",
+  240
+);
+
+const CLOUDS_SVG = svgUrl(
+  "<filter id='c'><feTurbulence type='fractalNoise' baseFrequency='0.013' numOctaves='3' stitchTiles='stitch' seed='5'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.55 -0.12'/></filter><rect width='100%' height='100%' filter='url(%23c)'/>",
+  480
+);
+
+const TARMAC_SVG = svgUrl(
+  "<filter id='t'><feTurbulence type='fractalNoise' baseFrequency='0.62' numOctaves='3' stitchTiles='stitch' seed='1'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.6 0'/></filter><rect width='100%' height='100%' filter='url(%23t)'/>",
+  220
+);
+
+function svgUrl(inner: string, size: number): string {
+  return `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='${size}' height='${size}'>${inner}</svg>")`;
+}
 
 function textureCSS(t: Texture) {
   switch (t) {
@@ -60,6 +81,32 @@ function textureCSS(t: Texture) {
       return css`
         background-image: ${NOISE_SVG};
         background-size: 160px 160px;
+      `;
+    case "paper":
+      return css`
+        background-image: ${PAPER_SVG};
+        background-size: 240px 240px;
+        mix-blend-mode: multiply;
+      `;
+    case "fabric":
+      return css`
+        background-image:
+          repeating-linear-gradient(0deg, rgba(0, 0, 0, 0.18) 0 1px, transparent 1px 4px),
+          repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.12) 0 1px, transparent 1px 4px),
+          radial-gradient(rgba(255, 255, 255, 0.04) 0.8px, transparent 1px);
+        background-size: 4px 4px, 4px 4px, 6px 6px;
+      `;
+    case "clouds":
+      return css`
+        background-image: ${CLOUDS_SVG};
+        background-size: 480px 480px;
+        mix-blend-mode: screen;
+      `;
+    case "tarmac":
+      return css`
+        background-image: ${TARMAC_SVG};
+        background-size: 220px 220px;
+        mix-blend-mode: multiply;
       `;
   }
 }

--- a/web/src/components/TextEffectSelect.tsx
+++ b/web/src/components/TextEffectSelect.tsx
@@ -1,0 +1,48 @@
+import styled from "styled-components";
+import { TEXT_EFFECTS } from "../effects";
+import { TextEffect } from "../types";
+
+type Props = {
+  value: TextEffect | null;
+  fallback?: TextEffect;
+  onChange: (e: TextEffect | null) => void;
+  allowInherit?: boolean;
+  inheritLabel?: string;
+  compact?: boolean;
+};
+
+const LABELS: Record<TextEffect, string> = {
+  none: "Plain",
+  shadow: "Shadow",
+  emboss: "Emboss",
+  engrave: "Engrave",
+  outline: "Outline",
+  glow: "Glow",
+};
+
+export function TextEffectSelect({ value, onChange, allowInherit, inheritLabel, compact }: Props) {
+  return (
+    <Select
+      $compact={!!compact}
+      value={value ?? "__inherit"}
+      onChange={(e) => onChange(e.target.value === "__inherit" ? null : (e.target.value as TextEffect))}
+    >
+      {allowInherit && <option value="__inherit">{inheritLabel ?? "Default"}</option>}
+      {TEXT_EFFECTS.map((t) => (
+        <option key={t} value={t}>{LABELS[t]}</option>
+      ))}
+    </Select>
+  );
+}
+
+const Select = styled.select<{ $compact: boolean }>`
+  height: ${(p) => (p.$compact ? "32px" : "40px")};
+  padding: 0 8px;
+  font-size: ${(p) => (p.$compact ? "0.85rem" : "1rem")};
+  background: #1a1a1a;
+  color: #f0f0f0;
+  border: 1px solid #444;
+  border-radius: 4px;
+  cursor: pointer;
+  &:hover { border-color: #666; }
+`;

--- a/web/src/effects.ts
+++ b/web/src/effects.ts
@@ -1,0 +1,35 @@
+import { CSSProperties } from "react";
+import { TextEffect } from "./types";
+
+export const TEXT_EFFECTS: TextEffect[] = ["none", "shadow", "emboss", "engrave", "outline", "glow"];
+
+export function textEffectStyle(effect: TextEffect): CSSProperties {
+  switch (effect) {
+    case "none":
+      return {};
+    case "shadow":
+      return {
+        textShadow: "0.04em 0.06em 0 rgba(0, 0, 0, 0.55)",
+      };
+    case "emboss":
+      return {
+        textShadow:
+          "-0.015em -0.015em 0 rgba(255, 255, 255, 0.6), 0.02em 0.025em 0.005em rgba(0, 0, 0, 0.55)",
+      };
+    case "engrave":
+      return {
+        textShadow:
+          "0.02em 0.025em 0 rgba(255, 255, 255, 0.55), -0.015em -0.015em 0 rgba(0, 0, 0, 0.5)",
+      };
+    case "outline":
+      return {
+        WebkitTextStroke: "0.025em rgba(0, 0, 0, 0.85)",
+        paintOrder: "stroke fill",
+      };
+    case "glow":
+      return {
+        textShadow:
+          "0 0 0.08em rgba(255, 255, 255, 0.95), 0 0 0.18em rgba(255, 255, 255, 0.6)",
+      };
+  }
+}

--- a/web/src/screens/Admin.tsx
+++ b/web/src/screens/Admin.tsx
@@ -2,15 +2,16 @@ import { ChangeEvent, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { api } from "../api";
 import { clearToken, getToken } from "../auth";
-import { Background, BoardAnimation, BoardState, Line, Texture } from "../types";
+import { Background, BoardAnimation, BoardState, Line, TextEffect, Texture } from "../types";
 import { LineEditor } from "../components/LineEditor";
 import { Toggle } from "../components/Toggle";
 import { Preview } from "../components/Preview";
 import { BackgroundEditor } from "../components/BackgroundEditor";
 import { FontSelect } from "../components/FontSelect";
+import { TextEffectSelect } from "../components/TextEffectSelect";
 import { Login } from "./Login";
 
-const newLine = (): Line => ({ id: crypto.randomUUID(), text: "", color: null, font: null });
+const newLine = (): Line => ({ id: crypto.randomUUID(), text: "", color: null, font: null, textEffect: null });
 
 function bgFallback(bg: Background): string {
   return bg.type === "solid" ? bg.color : bg.from;
@@ -130,6 +131,13 @@ export function Admin() {
               <FontSelect
                 value={draft.defaultFont}
                 onChange={(name) => update({ defaultFont: name ?? draft.defaultFont })}
+              />
+            </Row>
+            <Row>
+              <Caption style={{ width: 90 }}>Default effect</Caption>
+              <TextEffectSelect
+                value={draft.defaultTextEffect}
+                onChange={(e: TextEffect | null) => update({ defaultTextEffect: e ?? "none" })}
               />
             </Row>
           </Section>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -3,14 +3,16 @@ export type LinearBackground = { type: "linear"; from: string; to: string; angle
 export type RadialBackground = { type: "radial"; from: string; to: string };
 export type Background = SolidBackground | LinearBackground | RadialBackground;
 
-export type Texture = "none" | "dots" | "stripes" | "grid" | "noise";
+export type Texture = "none" | "dots" | "stripes" | "grid" | "noise" | "paper" | "fabric" | "clouds" | "tarmac";
 export type BoardAnimation = "none" | "pan" | "pulse" | "shimmer";
+export type TextEffect = "none" | "shadow" | "emboss" | "engrave" | "outline" | "glow";
 
 export type Line = {
   id: string;
   text: string;
   color: string | null;
   font: string | null;
+  textEffect: TextEffect | null;
 };
 
 export type BoardState = {
@@ -19,6 +21,7 @@ export type BoardState = {
   texture: Texture;
   animation: BoardAnimation;
   defaultFont: string;
+  defaultTextEffect: TextEffect;
   photoMode: boolean;
   imageName: string | null;
   updatedAt: number;


### PR DESCRIPTION
Textures (4 new, all CSS-only via inline SVG turbulence + repeating gradients — no asset bundling, no licensing):
- paper:  fine fractal grain, multiply blend so it darkens the bg
- fabric: woven thread look from layered repeating gradients + tiny highlight dots
- clouds: large soft turbulence, screen blend so it lightens the bg
- tarmac: dense high-frequency dark grain, multiply blend

Text effects (5 new, applied as a CSS preset map in src/effects.ts):
- shadow:  drop shadow
- emboss:  raised — bright highlight + dark inset
- engrave: sunken — bright lower + dark upper
- outline: text-stroke
- glow:    soft white halo

State adds defaultTextEffect (board-wide) and Line.textEffect (per-line override, null = inherit). Backend migrates and validates both.

Descender centering: replaced the fixed translateY(0.09em) hack — which only worked for all-caps fonts — with text-box-trim/text-box-edge inside an @supports block. Modern browsers trim the line box to the actual cap-to-text bounds so any font (Lobster, Permanent Marker, etc.) centers correctly without descenders bleeding into the next row. The translateY fallback is preserved for browsers without text-box-trim.

UI: BackgroundEditor lists the new textures; Admin Typography section gains a Default Effect picker; LineEditor packs the per-line font and text-effect selects into a small two-row group between the text input and colour swatch.

https://claude.ai/code/session_011pGzV6osudSkwYLZ93A74R